### PR TITLE
CU-8698mx6cj patch small issues

### DIFF
--- a/medcat2/components/linking/context_based_linker.py
+++ b/medcat2/components/linking/context_based_linker.py
@@ -49,7 +49,7 @@ class Linker(AbstractCoreComponent):
         return CoreComponentType.linking
 
     def _train(self, cui: str, entity: MutableEntity, doc: MutableDocument,
-               per_doc_valid_token_cache:  PerDocumentTokenCache,
+               per_doc_valid_token_cache: PerDocumentTokenCache,
                add_negative: bool = True) -> None:
         name = "{} - {}".format(entity.detected_name, cui)
         # TODO - bring back subsample after?
@@ -218,7 +218,9 @@ class Linker(AbstractCoreComponent):
               entity: MutableEntity,
               doc: MutableDocument,
               negative: bool = False,
-              names: Union[list[str], dict] = []) -> None:
+              names: Union[list[str], dict] = [],
+              per_doc_valid_token_cache: Optional[PerDocumentTokenCache] = None
+              ) -> None:
         """Train the linker.
 
         This simply trains the context model.
@@ -232,9 +234,13 @@ class Linker(AbstractCoreComponent):
             names (list[str]/dict):
                 Optionally used to update the `status` of a name-cui
                 pair in the CDB.
+            per_doc_valid_token_cache (PerDocumentTokenCache):
+                Optionally, provide the per doc valid token cache.
         """
-        pdc = PerDocumentTokenCache()
-        self.context_model.train(cui, entity, doc, pdc, negative, names)
+        if per_doc_valid_token_cache is None:
+            per_doc_valid_token_cache = PerDocumentTokenCache()
+        self.context_model.train(
+            cui, entity, doc, per_doc_valid_token_cache, negative, names)
 
     @classmethod
     def get_init_args(cls, tokenizer: BaseTokenizer, cdb: CDB, vocab: Vocab,

--- a/medcat2/components/linking/vector_context_model.py
+++ b/medcat2/components/linking/vector_context_model.py
@@ -200,7 +200,8 @@ class ContextModel(AbstractSerialisable):
             for i, (cui, sim) in enumerate(zip(cuis, similarities)):
                 if sim <= 0:
                     continue
-                status = self.name2info[name]['per_cui_status'][cui]
+                status = self.name2info[name]['per_cui_status'].get(
+                    cui, ST.AUTOMATIC)
                 if status in ST.PRIMARY_STATUS:
                     new_sim = sim * (1 + self.config.prefer_primary_name)
                     similarities[i] = min(0.99, new_sim)


### PR DESCRIPTION
Some issues came up when doing 2-step linker.

Some linker methods could benefit from passing existing per-doc token cache (if available).
Need to defualt to automatic CUI status when CUI not found.
Type IDs were (accidentally!) omitted in CDB conversion from v1.

This PR addresses all of the above.