### PR TITLE
CU-8698rbbtn Add model card

### DIFF
--- a/medcat2/__init__.py
+++ b/medcat2/__init__.py
@@ -1,0 +1,7 @@
+from importlib.metadata import version as __version_method
+from importlib.metadata import PackageNotFoundError as __PackageNotFoundError
+
+try:
+    __version__ = __version_method("medcat2")
+except __PackageNotFoundError:
+    __version__ = "0.0.0-dev"

--- a/medcat2/cat.py
+++ b/medcat2/cat.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Any
+from typing import Optional, Union, Any, overload, Literal
 import os
 import json
 
@@ -316,6 +316,14 @@ class CAT(AbstractSerialisable):
         #       after init so the CDB is likely "dirty"
         cat.cdb._reset_subnames()
         return cat
+
+    @overload
+    def get_model_card(self, as_dict: Literal[True]) -> ModelCard:
+        pass
+
+    @overload
+    def get_model_card(self, as_dict: Literal[False]) -> str:
+        pass
 
     def get_model_card(self, as_dict: bool = False) -> Union[str, ModelCard]:
         """Get the model card either a (nested) `dict` or a json string.

--- a/medcat2/cat.py
+++ b/medcat2/cat.py
@@ -339,7 +339,7 @@ class CAT(AbstractSerialisable):
             Union[str, ModelCard]: The model card.
         """
         meta_cat_categories = [
-            cnf.category_name  # type: ignore
+            cnf.general.category_name  # type: ignore
             for cnf in self.config.components.addons
             if cnf.comp_name == 'meta_cat' and
             # NOTE: not the best way to check this,

--- a/medcat2/cat.py
+++ b/medcat2/cat.py
@@ -250,6 +250,10 @@ class CAT(AbstractSerialisable):
         ensure_folder_if_parent(model_pack_path)
         # serialise
         serialise(serialiser_type, self, model_pack_path)
+        model_card: str = self.get_model_card(as_dict=False)
+        model_card_path = os.path.join(model_pack_path, "model_card.json")
+        with open(model_card_path, 'w') as f:
+            f.write(model_card)
         # components
         components_folder = os.path.join(
             model_pack_path, COMPONENTS_FOLDER)

--- a/medcat2/cat.py
+++ b/medcat2/cat.py
@@ -1,5 +1,6 @@
 from typing import Optional, Union, Any
 import os
+import json
 
 import shutil
 import logging
@@ -7,7 +8,7 @@ import logging
 from medcat2.utils.defaults import DEFAULT_PACK_NAME, COMPONENTS_FOLDER
 from medcat2.cdb import CDB
 from medcat2.vocab import Vocab
-from medcat2.config.config import Config
+from medcat2.config.config import Config, get_important_config_parameters
 from medcat2.trainer import Trainer
 from medcat2.storage.serialisers import serialise, AvailableSerialisers
 from medcat2.storage.serialisers import deserialise
@@ -17,6 +18,7 @@ from medcat2.utils.hasher import Hasher
 from medcat2.pipeline.pipeline import Pipeline
 from medcat2.tokenizing.tokens import MutableDocument, MutableEntity
 from medcat2.data.entities import Entity, Entities, OnlyCUIEntities
+from medcat2.data.model_card import ModelCard
 from medcat2.components.types import AbstractCoreComponent, HashableComponet
 from medcat2.components.addons.addons import AddonComponent
 
@@ -314,6 +316,42 @@ class CAT(AbstractSerialisable):
         #       after init so the CDB is likely "dirty"
         cat.cdb._reset_subnames()
         return cat
+
+    def get_model_card(self, as_dict: bool = False) -> Union[str, ModelCard]:
+        """Get the model card either a (nested) `dict` or a json string.
+
+        Args:
+            as_dict (bool): Whether to return as dict. Defaults to False.
+
+        Returns:
+            Union[str, ModelCard]: The model card.
+        """
+        meta_cat_categories = [
+            cnf.category_name  # type: ignore
+            for cnf in self.config.components.addons
+            if cnf.comp_name == 'meta_cat' and
+            # NOTE: not the best way to check this,
+            #       but I don't want to import the addon config
+            type(cnf).__name__ == 'ConfigMetaCAT']
+        cdb_info = self.cdb.get_basic_info()
+        model_card: ModelCard = {
+            'Model ID': self.config.meta.hash,
+            'Last Modified On': self.config.meta.last_saved.isoformat(),
+            'History (from least to most recent)': self.config.meta.history,
+            'Description': self.config.meta.description,
+            'Source Ontology': self.config.meta.ontology,
+            'Location': self.config.meta.location,
+            'MetaCAT models': meta_cat_categories,
+            'Basic CDB Stats': cdb_info,
+            'Performance': {},  # TODO
+            'Important Parameters (Partial view, '
+            'all available in cat.config)': get_important_config_parameters(
+                self.config),
+            'MedCAT Version': self.config.meta.medcat_version,
+        }
+        if as_dict:
+            return model_card
+        return json.dumps(model_card, indent=2, sort_keys=False)
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CAT):

--- a/medcat2/cdb/cdb.py
+++ b/medcat2/cdb/cdb.py
@@ -376,10 +376,12 @@ class CDB(AbstractSerialisable):
         else:
             average_count_train = 0.5
         unsup_history = [
-            history.model_dump() for history in self.config.meta.unsup_trained
+            history.model_dump(mode='json')
+            for history in self.config.meta.unsup_trained
         ]
         sup_history = [
-            history.model_dump() for history in self.config.meta.sup_trained
+            history.model_dump(mode='json')
+            for history in self.config.meta.sup_trained
         ]
         return {
             "Number of concepts": len(self.cui2info),

--- a/medcat2/cdb/cdb.py
+++ b/medcat2/cdb/cdb.py
@@ -8,6 +8,7 @@ from medcat2.utils.defaults import default_weighted_average, StatusTypes as ST
 from medcat2.utils.hasher import Hasher
 from medcat2.preprocessors.cleaners import NameDescriptor
 from medcat2.config import Config
+from medcat2.data.model_card import CDBInfo
 
 import logging
 
@@ -365,3 +366,16 @@ class CDB(AbstractSerialisable):
         hasher.update(self.get_cui2count_train())
         hasher.update(self.get_name2count_train())
         return hasher.hexdigest()
+
+    def get_basic_info(self) -> CDBInfo:
+        cui2ct = self.get_cui2count_train()
+        cuis_trained = len(cui2ct)
+        examples_seen = sum(cui2ct.values())
+        average_count_train = examples_seen / cuis_trained
+        return {
+            "Number of concepts": len(self.cui2info),
+            "Number of names": len(self.name2info),
+            "Number of concepts that received training": cuis_trained,
+            "Number of seen training examples in total": examples_seen,
+            "Average training examples per concept": average_count_train
+        }

--- a/medcat2/cdb/cdb.py
+++ b/medcat2/cdb/cdb.py
@@ -371,7 +371,10 @@ class CDB(AbstractSerialisable):
         cui2ct = self.get_cui2count_train()
         cuis_trained = len(cui2ct)
         examples_seen = sum(cui2ct.values())
-        average_count_train = examples_seen / cuis_trained
+        if cuis_trained:
+            average_count_train = examples_seen / cuis_trained
+        else:
+            average_count_train = 0.5
         unsup_history = [
             history.model_dump() for history in self.config.meta.unsup_trained
         ]

--- a/medcat2/cdb/cdb.py
+++ b/medcat2/cdb/cdb.py
@@ -372,10 +372,18 @@ class CDB(AbstractSerialisable):
         cuis_trained = len(cui2ct)
         examples_seen = sum(cui2ct.values())
         average_count_train = examples_seen / cuis_trained
+        unsup_history = [
+            history.model_dump() for history in self.config.meta.unsup_trained
+        ]
+        sup_history = [
+            history.model_dump() for history in self.config.meta.sup_trained
+        ]
         return {
             "Number of concepts": len(self.cui2info),
             "Number of names": len(self.name2info),
             "Number of concepts that received training": cuis_trained,
             "Number of seen training examples in total": examples_seen,
-            "Average training examples per concept": average_count_train
+            "Average training examples per concept": average_count_train,
+            "Unsupervised training history": unsup_history,
+            "Supervised training history": sup_history,
         }

--- a/medcat2/data/model_card.py
+++ b/medcat2/data/model_card.py
@@ -2,6 +2,17 @@ from typing import Any
 from typing_extensions import TypedDict
 
 
+CDBInfo = TypedDict(
+    "CDBInfo", {
+        "Number of concepts": int,
+        "Number of names": int,
+        "Number of concepts that received training": int,
+        "Number of seen training examples in total": int,
+        "Average training examples per concept": float,
+    }
+)
+
+
 ModelCard = TypedDict(
     "ModelCard", {
         "Model ID": str,
@@ -11,7 +22,7 @@ ModelCard = TypedDict(
         'Source Ontology': list[str],
         'Location': str,
         'MetaCAT models': list[str],
-        'Basic CDB Stats': dict[str, Any],
+        'Basic CDB Stats': CDBInfo,
         'Performance': dict[str, Any],
         ('Important Parameters '
          '(Partial view, all available in cat.config)'): dict[str, Any],

--- a/medcat2/data/model_card.py
+++ b/medcat2/data/model_card.py
@@ -1,0 +1,20 @@
+from typing import Any
+from typing_extensions import TypedDict
+
+
+ModelCard = TypedDict(
+    "ModelCard", {
+        "Model ID": str,
+        "Last Modified On": str,
+        "History (from least to most recent)": list[str],
+        'Description': str,
+        'Source Ontology': list[str],
+        'Location': str,
+        'MetaCAT models': list[str],
+        'Basic CDB Stats': dict[str, Any],
+        'Performance': dict[str, Any],
+        ('Important Parameters '
+         '(Partial view, all available in cat.config)'): dict[str, Any],
+        'MedCAT Version': str,
+    }
+)

--- a/medcat2/data/model_card.py
+++ b/medcat2/data/model_card.py
@@ -9,6 +9,8 @@ CDBInfo = TypedDict(
         "Number of concepts that received training": int,
         "Number of seen training examples in total": int,
         "Average training examples per concept": float,
+        "Unsupervised training history": list[dict[str, Any]],
+        "Supervised training history": list[dict[str, Any]],
     }
 )
 

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -5,6 +5,7 @@ from typing import Optional
 from collections import Counter
 
 from medcat2 import cat
+from medcat2.data.model_card import ModelCard
 from medcat2.vocab import Vocab
 from medcat2.config import Config
 from medcat2.model_creation.cdb_maker import CDBMaker
@@ -147,6 +148,26 @@ class CATCreationTests(CATIncludingTests):
         sorted_set = sorted(set(self.cat.config.meta.history))
         sorted_list = sorted(self.cat.config.meta.history)
         self.assertEqual(sorted_set, sorted_list)
+
+    def test_can_get_model_card_str(self):
+        model_card = self.cat.get_model_card(as_dict=False)
+        self.assertIsInstance(model_card, str)
+
+    def test_can_get_model_card_dict(self):
+        model_card = self.cat.get_model_card(as_dict=True)
+        self.assertIsInstance(model_card, dict)
+
+    def test_model_card_has_required_keys(self):
+        model_card = self.cat.get_model_card(as_dict=True)
+        for ann in ModelCard.__annotations__:
+            with self.subTest(f"Ann: {ann}"):
+                self.assertIn(ann, model_card)
+
+    def test_model_card_has_no_extra_keys(self):
+        model_card = self.cat.get_model_card(as_dict=True)
+        for key in model_card:
+            with self.subTest(f"Key: {key}"):
+                self.assertIn(key, ModelCard.__annotations__)
 
 
 class CATUnsupTrainingTests(CATCreationTests):


### PR DESCRIPTION
Add model card to MedCAT v2.

This is very similar to model card in v1.
An example could look something like this:
```
{
  "Model ID": "67fc90ee4c4227a6",
  "Last Modified On": "2025-04-15T17:10:38.462090",
  "History (from least to most recent)": [
    "67fc90ee4c4227a6"
  ],
  "Description": "This is a UK KCH medcat model. Created on the 20220913. It contains mappings to ICD10 and OPCS4. Enjoy!",
  "Source Ontology": [
    "20220803_SNOMED_UK_clinical_ext",
    "20220831_SNOMED_UK_drug_ext",
    "Enriched via UMLS v2022AA English terms only"
  ],
  "Location": "N/A",
  "MetaCAT models": [
    "Presence",
    "Subject",
    "Time"
  ],
  "Basic CDB Stats": {
    "Number of concepts": 760283,
    "Number of names": 3080847,
    "Number of concepts that received training": 38460,
    "Number of seen training examples in total": 153875883,
    "Average training examples per concept": 4000.932995319813,
    "Unsupervised training history": [],
    "Supervised training history": []
  },
  "Performance": {},
  "Important Parameters (Partial view, all available in cat.config)": {
    "config.ponents.ner.min_name_len": {
      "value": 2,
      "description": "Minimum detection length (found terms/mentions shorter than this will not be detected)."
    },
    "config.ponents.ner.upper_case_limit_len": {
      "value": 2,
      "description": "All detected terms shorter than this value have to be uppercase, otherwise they will be ignored."
    },
    "config.ponents.linking.similarity_threshold": {
      "value": 0.3,
      "description": "If the confidence of the model is lower than this a detection will be ignore."
    },
    "config.ponents.linking.filters.cuis": {
      "value": 0,
      "description": "Length of the CUIs filter to be included in outputs. If this is not 0 (i.e. not empty) its best to check what is included before using the model"
    },
    "config.general.spell_check": {
      "value": true,
      "description": "Is spell checking enabled."
    },
    "config.general.spell_check_len_limit": {
      "value": 4,
      "description": "Words shorter than this will not be spell checked."
    }
  },
  "MedCAT Version": "2.0.0.dev0"
}
```