### PR TITLE
CU-8698waymx old conversion

### DIFF
--- a/medcat2/utils/legacy/conversion_all.py
+++ b/medcat2/utils/legacy/conversion_all.py
@@ -13,6 +13,7 @@ from medcat2.utils.legacy.convert_config import get_config_from_old
 from medcat2.utils.legacy.convert_vocab import get_vocab_from_old
 from medcat2.utils.legacy.convert_meta_cat import get_meta_cat_from_old
 from medcat2.utils.legacy.convert_deid import get_trf_ner_from_old
+from medcat2.utils.legacy.helpers import fix_subnames
 
 
 logger = logging.getLogger(__name__)
@@ -77,6 +78,7 @@ class Converter:
         else:
             config = cdb.config
         cat = CAT(cdb, vocab, config)
+        fix_subnames(cat)
         # MetaCATs
         meta_cats = [
             get_meta_cat_from_old(

--- a/medcat2/utils/legacy/convert_config.py
+++ b/medcat2/utils/legacy/convert_config.py
@@ -154,7 +154,12 @@ def get_config_from_nested_dict(old_data: dict) -> Config:
     # v1 models always used spacy
     # but we now default to regex
     cnf.general.nlp.provider = 'spacy'
-    return _make_changes(cnf, old_data)
+    cnf = _make_changes(cnf, old_data)
+    if cnf.general.nlp.modelname == 'spacy_model':
+        logger.info("Fixing spacy model. "
+                    "Moving from 'spacy_model' to 'en_core_web_md'!")
+        cnf.general.nlp.modelname = 'en_core_web_md'
+    return cnf
 
 
 def get_config_from_old(path: str) -> Config:

--- a/medcat2/utils/legacy/helpers.py
+++ b/medcat2/utils/legacy/helpers.py
@@ -1,0 +1,39 @@
+from medcat2.cat import CAT
+from medcat2.cdb.cdb import CDB
+from medcat2.preprocessors.cleaners import prepare_name, NameDescriptor
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def has_per_concept_subnames(cdb: CDB) -> bool:
+    for ci in cdb.cui2info.values():
+        if ci['subnames']:
+            return True
+    return False
+
+
+def _fix_subnames(cat: CAT) -> None:
+    tknzer = cat._pipeline.tokenizer_with_tag
+    for ci in cat.cdb.cui2info.values():
+        names: dict[str, NameDescriptor] = {}
+        for name in ci['names']:
+            prepare_name(
+                name, tknzer, names, (cat.config.general,
+                                      cat.config.preprocessing,
+                                      cat.config.cdb_maker))
+        for name, descr in names.items():
+            ci['subnames'].update(descr.snames)
+            cat.cdb._subnames.update(descr.snames)
+
+
+def fix_subnames(cat: CAT) -> None:
+    # NOTE: old v1 models may have not stored subnames (snames)
+    #       on a per concept basis so we may need to rebuild that
+    if has_per_concept_subnames(cat.cdb):
+        return
+    logger.info(
+        "The previous CAT had no per-concept subnames. Adding them now.")
+    _fix_subnames(cat)

--- a/medcat2/utils/legacy/legacy_converter.py
+++ b/medcat2/utils/legacy/legacy_converter.py
@@ -5,6 +5,7 @@ import logging
 
 from medcat2.utils.legacy.conversion_all import Converter, logger as clogger
 from medcat2.storage.serialisers import AvailableSerialisers
+from medcat2.utils.legacy.helpers import logger as hlogger
 
 
 def do_conversion(file_from: str, file_to: str,
@@ -38,9 +39,12 @@ def main(argv: Optional[list[str]] = None):
                         'does not exist', action='store_true')
     args = parser.parse_args(args=argv)
     if not args.silent:
-        clogger.addHandler(logging.StreamHandler())
+        sh = logging.StreamHandler()
+        clogger.addHandler(sh)
+        hlogger.addHandler(sh)
     if args.verbose:
         clogger.setLevel(logging.DEBUG)
+        hlogger.setLevel(logging.DEBUG)
     if not os.path.exists(args.new_model) and args.new_folder:
         print("Creating new folder:", args.new_model)
         os.mkdir(args.new_model)

--- a/tests/utils/legacy/test_conversion_all.py
+++ b/tests/utils/legacy/test_conversion_all.py
@@ -6,6 +6,7 @@ from medcat2.cat import CAT
 import shutil
 
 import unittest
+import unittest.mock
 
 from .test_convert_vocab import TESTS_PATH
 
@@ -18,7 +19,11 @@ class ConversionFromZIPTests(unittest.TestCase):
     def setUpClass(cls):
         cls._model_folder_no_zip = cls.MODEL_FOLDER.rsplit(".zip", 1)[0]
         cls._folder_existed = os.path.exists(cls._model_folder_no_zip)
-        cls.converter = conversion_all.Converter(cls.MODEL_FOLDER, None)
+        # make sure the subnames are not fixed for normal models
+        with unittest.mock.patch("medcat2.utils.legacy.helpers._fix_subnames"
+                                 ) as mock:
+            cls.converter = conversion_all.Converter(cls.MODEL_FOLDER, None)
+        mock.assert_not_called()
         cls.cat = cls.converter.convert()
 
     @classmethod


### PR DESCRIPTION
Fix some issue converting way older models.
These models stated their `spacy_model` was just called `spacy_model` and had no per concept `snames` (or `subnames`) defined.
This PR will allow these models to still be convertible.