### PR TITLE
CU-8698x076x Fix final ent order

### DIFF
--- a/medcat2/utils/postprocessing.py
+++ b/medcat2/utils/postprocessing.py
@@ -23,4 +23,5 @@ def create_main_ann(doc: MutableDocument) -> None:
             for tkn in ent:
                 tkns_in.add(tkn)
             main_anns.append(ent)
-    doc.final_ents = list(doc.final_ents) + main_anns  # type: ignore
+    doc.final_ents = sorted(list(doc.final_ents) + main_anns,  # type: ignore
+                            key=lambda ent: ent.base.start_char_index)

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -77,6 +77,15 @@ class InferenceFromLoadedTests(TrainedModelTests):
             with self.subTest(f"{nr}"):
                 ConvertedFunctionalityTests.assert_has_ent(ent)
 
+    def test_entities_in_correct_order(self):
+        # NOTE: the issue wouldn't show up with smaller amount of text
+        doc = self.model(ConvertedFunctionalityTests.TEXT * 3)
+        cur_start = 0
+        for ent in doc.final_ents:
+            with self.subTest(f"Ent: {ent}"):
+                self.assertGreaterEqual(ent.base.start_char_index, cur_start)
+                cur_start = ent.base.start_char_index
+
 
 class CATIncludingTests(unittest.TestCase):
     TOKENIZING_PROVIDER = 'regex'


### PR DESCRIPTION
Sometimes (for some reason) the the entities in `doc.final_ents` would not in the order that they appear in the text.

This PR fixes that by sorting the entities upon setting them.
It also adds a small test that makes sure this remains the case.

PS:
I checked, and the new test failed without the change. But not for a smaller piece of text.