### PR TITLE
8698x6x0d remove flake8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Ruff linting
         run: |
           uv run ruff check medcat2
-      - name: Flake8 lint
-        run: |
-          uv run python -m flake8 medcat2
       - name: Test
         run: |
           timeout 10m uv run python -m unittest discover

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ dependencies = [ # Optional
 dev = [
   "ruff~=0.1.7",
   "mypy",
-  "flake8",
 ]
 spacy = [
   "spacy",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,0 @@
-ruff~=0.1.7
-flake8~=7.1.1
-mypy~=1.12.1
-types-tqdm
-types-setuptools


### PR DESCRIPTION
We've got `ruff` anyway. We'll stick to one linker.

Also removed the unused `requirements-dev.txt`. All requirements should be defined in `pyproject.toml`.