### PR TITLE
CU-8698x6yzc automatic v1 conversion

### DIFF
--- a/medcat2/cat.py
+++ b/medcat2/cat.py
@@ -21,7 +21,7 @@ from medcat2.data.entities import Entity, Entities, OnlyCUIEntities
 from medcat2.data.model_card import ModelCard
 from medcat2.components.types import AbstractCoreComponent, HashableComponet
 from medcat2.components.addons.addons import AddonComponent
-from medcat2.utils.legacy.helpers import is_legacy_model_pack
+from medcat2.utils.legacy.identifier import is_legacy_model_pack
 from medcat2.utils.defaults import AVOID_LEGACY_CONVERSION_ENVIRON
 
 

--- a/medcat2/cat.py
+++ b/medcat2/cat.py
@@ -21,6 +21,8 @@ from medcat2.data.entities import Entity, Entities, OnlyCUIEntities
 from medcat2.data.model_card import ModelCard
 from medcat2.components.types import AbstractCoreComponent, HashableComponet
 from medcat2.components.addons.addons import AddonComponent
+from medcat2.utils.legacy.helpers import is_legacy_model_pack
+from medcat2.utils.defaults import AVOID_LEGACY_CONVERSION_ENVIRON
 
 
 logger = logging.getLogger(__name__)
@@ -309,6 +311,23 @@ class CAT(AbstractSerialisable):
             model_pack_path = folder_path
         logger.info("Attempting to load model from file: %s",
                     model_pack_path)
+        is_legacy = is_legacy_model_pack(model_pack_path)
+        should_avoid = os.environ.get(
+            AVOID_LEGACY_CONVERSION_ENVIRON, "False").lower() == "true"
+        if is_legacy and not should_avoid:
+            from medcat2.utils.legacy.conversion_all import Converter
+            logger.warning(
+                "Doing legacy conversion on model pack '%s'. "
+                "This will make the model load take significantly longer. "
+                "If you wish to avoid this, set the environment variable '%s' "
+                "to 'true'", model_pack_path, AVOID_LEGACY_CONVERSION_ENVIRON)
+            return Converter(model_pack_path, None).convert()
+        elif is_legacy and not should_avoid:
+            raise ValueError(
+                f"The model pack '{model_pack_path}' is a legacy model pack. "
+                "Please set the environment variable "
+                f"'{AVOID_LEGACY_CONVERSION_ENVIRON}' "
+                "to 'true' to allow automatic conversion.")
         # NOTE: ignoring addons since they will be loaded later / separately
         cat = deserialise(model_pack_path, model_load_path=model_pack_path,
                           ignore_folders_prefix={

--- a/medcat2/cat.py
+++ b/medcat2/cat.py
@@ -322,7 +322,7 @@ class CAT(AbstractSerialisable):
                 "If you wish to avoid this, set the environment variable '%s' "
                 "to 'true'", model_pack_path, AVOID_LEGACY_CONVERSION_ENVIRON)
             return Converter(model_pack_path, None).convert()
-        elif is_legacy and not should_avoid:
+        elif is_legacy and should_avoid:
             raise ValueError(
                 f"The model pack '{model_pack_path}' is a legacy model pack. "
                 "Please set the environment variable "

--- a/medcat2/utils/defaults.py
+++ b/medcat2/utils/defaults.py
@@ -6,6 +6,7 @@ from functools import lru_cache
 DEFAULT_SPACY_MODEL = 'en_core_web_md'
 DEFAULT_PACK_NAME = "medcat2_model_pack"
 COMPONENTS_FOLDER = "saved_components"
+AVOID_LEGACY_CONVERSION_ENVIRON = "MEDCAT_AVOID_LECACY_CONVERSION"
 
 
 @lru_cache(maxsize=100)

--- a/medcat2/utils/legacy/identifier.py
+++ b/medcat2/utils/legacy/identifier.py
@@ -1,0 +1,25 @@
+import os
+
+EXPECTED_V1_CDB_FILE_NAME = "cdb.dat"
+EXPECTED_V2_CDB_FOLDER_NAME = "cdb"
+
+
+def is_legacy_model_pack(model_pack_path: str) -> bool:
+    """Check if the model pack is a legacy model pack.
+
+    Args:
+        model_pack_path (str): The path to the model pack (unzipped).
+
+    Returns:
+        bool: True if the model pack is a legacy model pack, False otherwise.
+    """
+    if not os.path.isdir(model_pack_path):
+        raise ValueError(
+            f"Provided model pack path is not a directory: {model_pack_path}")
+    cdb_path_v1 = os.path.join(model_pack_path, EXPECTED_V1_CDB_FILE_NAME)
+    cdb_path_v2 = os.path.join(model_pack_path, EXPECTED_V2_CDB_FOLDER_NAME)
+    return (
+        # has cdb.dat and it is a file
+        os.path.exists(cdb_path_v1) and os.path.isfile(cdb_path_v1) and
+        # does not have cdb folder
+        not os.path.exists(cdb_path_v2))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,6 +7,9 @@ RESOURCES_PATH = os.path.join(os.path.dirname(__file__), "resources")
 EXAMPLE_MODEL_PACK_ZIP = os.path.join(RESOURCES_PATH, "mct2_model_pack.zip")
 UNPACKED_EXAMPLE_MODEL_PACK_PATH = os.path.join(
     RESOURCES_PATH, "mct2_model_pack")
+V1_MODEL_PACK_PATH = os.path.join(RESOURCES_PATH, "mct_v1_model_pack.zip")
+UNPACKED_V1_MODEL_PACK_PATH = os.path.join(
+    RESOURCES_PATH, "mct_v1_model_pack")
 
 
 # unpack model pack at start so we can access stuff like Vocab
@@ -14,11 +17,16 @@ print("Unpacking included test model pack")
 shutil.unpack_archive(
     EXAMPLE_MODEL_PACK_ZIP, UNPACKED_EXAMPLE_MODEL_PACK_PATH)
 
+print("Unpacking the included v1 model pack for test time")
+shutil.unpack_archive(
+    V1_MODEL_PACK_PATH, UNPACKED_V1_MODEL_PACK_PATH)
+
 
 def _del_unpacked_model():
     print("Cleaning up! Removing unpacked exmaple model pack:",
           UNPACKED_EXAMPLE_MODEL_PACK_PATH)
     shutil.rmtree(UNPACKED_EXAMPLE_MODEL_PACK_PATH)
+    shutil.rmtree(UNPACKED_V1_MODEL_PACK_PATH)
 
 
 atexit.register(_del_unpacked_model)

--- a/tests/components/addons/meta_cat/test_meta_cat.py
+++ b/tests/components/addons/meta_cat/test_meta_cat.py
@@ -8,12 +8,8 @@ from medcat2.config.config_meta_cat import ConfigMetaCAT
 from medcat2.config.config import Config
 
 import unittest
-import unittest.mock
 import tempfile
 
-from transformers import AutoTokenizer
-from medcat2.components.addons.meta_cat.mctokenizers.bert_tokenizer import (
-    TokenizerWrapperBERT)
 from medcat2.cat import CAT
 from medcat2.tokenizing.spacy_impl.tokenizers import SpacyTokenizer
 

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -1,4 +1,5 @@
 import os
+import unittest.mock
 import pandas as pd
 import json
 from typing import Optional
@@ -14,10 +15,12 @@ from medcat2.cdb import CDB
 from medcat2.tokenizing.tokens import UnregisteredDataPathException
 from medcat2.utils.cdb_state import captured_state_cdb
 from medcat2.components.addons.meta_cat.meta_cat import MetaCATAddon
+from medcat2.utils.defaults import AVOID_LEGACY_CONVERSION_ENVIRON
 
 import unittest
 
 from . import EXAMPLE_MODEL_PACK_ZIP
+from . import V1_MODEL_PACK_PATH, UNPACKED_V1_MODEL_PACK_PATH
 from .utils.legacy.test_conversion_all import ConvertedFunctionalityTests
 
 
@@ -413,3 +416,20 @@ class CATWithEntityAddonTests(CATIncludingTests):
 
 class CATWithEntityAddonSpacyTests(CATWithEntityAddonTests):
     TOKENIZING_PROVIDER = 'spacy'
+
+
+class CATLegacyLoadTests(unittest.TestCase):
+
+    def test_can_load_legacy_model_zip(self):
+        self.assertIsInstance(
+            cat.CAT.load_model_pack(V1_MODEL_PACK_PATH), cat.CAT)
+
+    def test_can_load_legacy_model_unpacked(self):
+        self.assertIsInstance(
+            cat.CAT.load_model_pack(UNPACKED_V1_MODEL_PACK_PATH), cat.CAT)
+
+    def test_cannot_load_legacy_with_environ_set(self):
+        with unittest.mock.patch.dict(os.environ, {
+                AVOID_LEGACY_CONVERSION_ENVIRON: "true"}, clear=True):
+            with self.assertRaises(ValueError):
+                cat.CAT.load_model_pack(V1_MODEL_PACK_PATH)

--- a/tests/utils/legacy/test_conversion_all.py
+++ b/tests/utils/legacy/test_conversion_all.py
@@ -3,8 +3,6 @@ import os
 from medcat2.utils.legacy import conversion_all
 from medcat2.cat import CAT
 
-import shutil
-
 import unittest
 import unittest.mock
 

--- a/tests/utils/legacy/test_conversion_all.py
+++ b/tests/utils/legacy/test_conversion_all.py
@@ -26,13 +26,6 @@ class ConversionFromZIPTests(unittest.TestCase):
         mock.assert_not_called()
         cls.cat = cls.converter.convert()
 
-    @classmethod
-    def tearDownClass(cls):
-        if cls.MODEL_FOLDER.endswith(".zip"):
-            folder = cls._model_folder_no_zip
-            if os.path.exists(folder) and not cls._folder_existed:
-                shutil.rmtree(folder)
-
     def test_creates_cat(self):
         self.assertIsInstance(self.cat, CAT)
 

--- a/tests/utils/legacy/test_identifier.py
+++ b/tests/utils/legacy/test_identifier.py
@@ -1,0 +1,14 @@
+from medcat2.utils.legacy import identifier
+
+from unittest import TestCase
+
+from ... import UNPACKED_EXAMPLE_MODEL_PACK_PATH as v2_model_pack_path
+from ... import UNPACKED_V1_MODEL_PACK_PATH as v1_model_pack_path
+
+
+class CanIdentifyLegacyModelPackTests(TestCase):
+    def test_can_identify_legacy_model_pack(self):
+        self.assertTrue(identifier.is_legacy_model_pack(v1_model_pack_path))
+
+    def test_can_identify_v2_model_pack(self):
+        self.assertFalse(identifier.is_legacy_model_pack(v2_model_pack_path))


### PR DESCRIPTION
Add option (enabled by default) to do automatic conversion of v1 models on the fly when loading a model.

The option is controlled by `MEDCAT_AVOID_LECACY_CONVERSION` environmental variable.
This defaults to `false`. However, when set to `true`, an attempt to convert will result in an exception being raised.

Also adds a few relevant tests and removes a few irrelevant imports in some other tests.