### PR TITLE
Fix test regarding installed dependencies - use lower case dep names

### DIFF
--- a/medcat2/utils/envsnapshot.py
+++ b/medcat2/utils/envsnapshot.py
@@ -32,7 +32,7 @@ def get_direct_dependencies(include_extras: bool) -> list[str]:
                 if "; extra ==" not in req]
     # only keep name, not version
     # NOTE: all correct dependency names will match this regex
-    reqs = [DEP_NAME_PATTERN.match(req).group(0)  # type: ignore
+    reqs = [DEP_NAME_PATTERN.match(req).group(0).lower()  # type: ignore
             for req in reqs]
     return reqs
 
@@ -90,7 +90,7 @@ def get_installed_dependencies(include_extras: bool) -> dict[str, str]:
     direct_deps = get_direct_dependencies(include_extras)
     installed_packages: dict[str, str] = {}
     for package in pkg_resources.working_set:
-        if package.project_name not in direct_deps:
+        if package.project_name.lower() not in direct_deps:
             continue
         installed_packages[package.project_name] = package.version
     return installed_packages

--- a/medcat2/utils/envsnapshot.py
+++ b/medcat2/utils/envsnapshot.py
@@ -40,12 +40,12 @@ def get_direct_dependencies(include_extras: bool) -> list[str]:
 def _update_installed_dependencies_recursive(
         gathered: dict[str, str],
         package: pkg_resources.Distribution) -> dict[str, str]:
-    if package.project_name in gathered:
+    if package.project_name.lower() in gathered:
         logger.debug("Trying to update already found transitive dependency "
                      "'%'", package.egg_name)
         return gathered
     for req in package.requires():
-        if req.project_name in gathered:
+        if req.project_name.lower() in gathered:
             logger.debug("Trying to look up already found transitive "
                          "dependency '%'", req.project_name)
             continue  # don't look for it again
@@ -57,7 +57,7 @@ def _update_installed_dependencies_recursive(
             continue
         _update_installed_dependencies_recursive(gathered, dep)
         # do this after so its dependencies get explored
-        gathered[dep.project_name] = dep.version
+        gathered[dep.project_name.lower()] = dep.version
     return gathered
 
 
@@ -92,7 +92,7 @@ def get_installed_dependencies(include_extras: bool) -> dict[str, str]:
     for package in pkg_resources.working_set:
         if package.project_name.lower() not in direct_deps:
             continue
-        installed_packages[package.project_name] = package.version
+        installed_packages[package.project_name.lower()] = package.version
     return installed_packages
 
 

--- a/tests/utils/test_envsnapshot.py
+++ b/tests/utils/test_envsnapshot.py
@@ -10,9 +10,13 @@ class DependencyGetterTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.dir_deps = envsnapshot.get_direct_dependencies(cls.INCLUDE_EXTRAS)
-        cls.installed_deps = envsnapshot.get_installed_dependencies(
-            cls.INCLUDE_EXTRAS)
+        cls.dir_deps = [
+            dep.lower() for dep in
+            envsnapshot.get_direct_dependencies(cls.INCLUDE_EXTRAS)]
+        cls.installed_deps = {
+            dep.lower(): version for dep, version in
+            envsnapshot.get_installed_dependencies(cls.INCLUDE_EXTRAS).items()
+        }
         cls.trans_deps = envsnapshot.get_transitive_deps(
             list(cls.installed_deps.keys()))
 


### PR DESCRIPTION
Some dependencies have a lower case name when installed in the GHA workflow. But that makes the test fail since it assumes case-sensitivity.

So this PR makes the tests only check lower case names.