### PR TITLE
CU-869911jtc: Fix regex-based tokenizer data issues

### DIFF
--- a/medcat2/tokenizing/regex_impl/tokenizer.py
+++ b/medcat2/tokenizing/regex_impl/tokenizer.py
@@ -183,9 +183,10 @@ class Entity:
         # NOTE: registering for document since that should be constant
         # whereas the entities may be created and recreated
         # it'll map the entity start and end index to the value
-        def_val = defaultdict(lambda: def_val)
+        def_val_doc = defaultdict(lambda: def_val)
         Document.register_addon_path(
-            f"{cls.ENTITY_INFO_PREFIX}{path}", def_val=def_val, force=force)
+            f"{cls.ENTITY_INFO_PREFIX}{path}", def_val=def_val_doc,
+            force=force)
 
     def __iter__(self) -> Iterator[MutableToken]:
         for tkn in self._doc._tokens[self.start_index: self.end_index]:

--- a/medcat2/tokenizing/regex_impl/tokenizer.py
+++ b/medcat2/tokenizing/regex_impl/tokenizer.py
@@ -183,7 +183,7 @@ class Entity:
         # NOTE: registering for document since that should be constant
         # whereas the entities may be created and recreated
         # it'll map the entity start and end index to the value
-        def_val_doc = defaultdict(lambda: def_val)
+        def_val_doc: dict = defaultdict(lambda: def_val)
         Document.register_addon_path(
             f"{cls.ENTITY_INFO_PREFIX}{path}", def_val=def_val_doc,
             force=force)

--- a/tests/tokenizing/regex_impl/test_tokenizer.py
+++ b/tests/tokenizing/regex_impl/test_tokenizer.py
@@ -32,3 +32,61 @@ class TokenizerTests(TestCase):
     def test_doc_has_correct_tokens(self):
         self.assertEqual([tkn.base.text for tkn in self.tokens],
                          self.EXP_TOKENS)
+
+
+class EntitySimpleAddonDataTests(TestCase):
+    EXAMPLE_TEXT = "Some example text"
+    ADDON_PATH = "test_time_addon"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tokenizer = tokenizer.RegexTokenizer()
+        cls.tokenizer.get_entity_class().register_addon_path(cls.ADDON_PATH)
+
+    def _make_tokens_entities(self):
+        num_tokens = len(self.doc)
+        for ent_num in range(num_tokens):
+            ent = self.doc[ent_num: ent_num + 1]
+            self.doc.all_ents.append(ent)
+
+    def _set_single_entity_data(self, ent_num: int,
+                                entity: tokenizer.MutableEntity):
+        entity.set_addon_data(self.ADDON_PATH, ent_num)
+
+    def _get_expected_data(self, ent_num: int,
+                           entity: tokenizer.MutableEntity):
+        return ent_num
+
+    def _set_per_entity_data(self):
+        for ent_num, entity in enumerate(self.doc.all_ents):
+            self._set_single_entity_data(ent_num, entity)
+
+    def setUp(self):
+        self.doc = self.tokenizer(self.EXAMPLE_TEXT)
+        # add all tokens as entities
+        self._make_tokens_entities()
+        # set addon data for all tokens
+        self._set_per_entity_data()
+
+    def test_can_get_addon_data(self):
+        self.assertGreater(len(self.doc.all_ents), 0)
+        for ent_num, entity in enumerate(self.doc.all_ents):
+            with self.subTest(f"Entity {ent_num}: {entity}"):
+                data_val = entity.get_addon_data(self.ADDON_PATH)
+                self.assertEqual(data_val, self._get_expected_data(
+                    ent_num, entity))
+
+
+class EntityComplexAddonTests(EntitySimpleAddonDataTests):
+    ADDON_PATH = "complex_data_path"
+
+    def _set_single_entity_data(self, ent_num: int,
+                                entity: tokenizer.MutableEntity):
+        if (data := entity.get_addon_data(self.ADDON_PATH)) is not None:
+            data[len(data)] = ent_num
+        else:
+            entity.set_addon_data(self.ADDON_PATH, {0: ent_num})
+
+    def _get_expected_data(self, ent_num: int,
+                           entity: tokenizer.MutableEntity):
+        return {0: ent_num}


### PR DESCRIPTION
This mostly affected MetaCAT. The default value used for the additional data was referring to itself.

This PR fixes that issue.

PS: The first commit is expected to fail due to added test. The next commit should fix the issue.