### PR TITLE
CU-869911jtc Fix Meta cat

### DIFF
--- a/medcat2/components/addons/meta_cat/meta_cat.py
+++ b/medcat2/components/addons/meta_cat/meta_cat.py
@@ -245,7 +245,7 @@ class MetaCAT(AbstractSerialisable):
 
         self.tokenizer = tokenizer
         if tokenizer is not None:
-            self.reset_tokenizer_info()
+            self._reset_tokenizer_info()
 
         self.embeddings = (torch.tensor(
             embeddings, dtype=torch.float32) if embeddings is not None
@@ -254,7 +254,7 @@ class MetaCAT(AbstractSerialisable):
         if _model_state_dict:
             self.model.load_state_dict(_model_state_dict)
 
-    def reset_tokenizer_info(self):
+    def _reset_tokenizer_info(self):
         # Set it in the config
         self.config.general.tokenizer_name = self.tokenizer.name
         self.config.general.vocab_size = self.tokenizer.get_size()

--- a/medcat2/components/addons/meta_cat/meta_cat.py
+++ b/medcat2/components/addons/meta_cat/meta_cat.py
@@ -236,13 +236,9 @@ class MetaCAT(AbstractSerialisable):
         self.config = config
         set_all_seeds(config.general.seed)
 
-        if tokenizer is not None:
-            # Set it in the config
-            config.general.tokenizer_name = tokenizer.name
-            config.general.vocab_size = tokenizer.get_size()
-            # We will also set the padding
-            config.model.padding_idx = cast(int, tokenizer.get_pad_id())
         self.tokenizer = tokenizer
+        if tokenizer is not None:
+            self.reset_tokenizer_info()
 
         self.embeddings = (torch.tensor(
             embeddings, dtype=torch.float32) if embeddings is not None
@@ -250,6 +246,13 @@ class MetaCAT(AbstractSerialisable):
         self.model = self.get_model(embeddings=self.embeddings)
         if _model_state_dict:
             self.model.load_state_dict(_model_state_dict)
+
+    def reset_tokenizer_info(self):
+        # Set it in the config
+        self.config.general.tokenizer_name = self.tokenizer.name
+        self.config.general.vocab_size = self.tokenizer.get_size()
+        # We will also set the padding
+        self.config.model.padding_idx = cast(int, self.tokenizer.get_pad_id())
 
     def get_model(self, embeddings: Optional[Tensor]) -> nn.Module:
         """Get the model

--- a/medcat2/components/addons/meta_cat/meta_cat.py
+++ b/medcat2/components/addons/meta_cat/meta_cat.py
@@ -4,7 +4,7 @@ import logging
 import numpy
 from multiprocessing import Lock
 from datetime import datetime
-from typing import Iterable, Optional, cast, Union, Any, TypedDict
+from typing import Iterable, Optional, cast, Union, Any, TypedDict, Callable
 
 from medcat2.utils.hasher import Hasher
 
@@ -44,6 +44,10 @@ class MedCATTrainerExportDocument(TypedDict):
     value: str
 
 
+TokenizerPreprocessor = Optional[
+    Callable[[Optional[TokenizerWrapperBase]], None]]
+
+
 class MetaCATAddon(AddonComponent):
     addon_type = 'meta_cat'
     output_key = 'meta_anns'
@@ -64,10 +68,13 @@ class MetaCATAddon(AddonComponent):
         return self._mc
 
     @classmethod
-    def create_new(cls, config: ConfigMetaCAT, base_tokenizer: BaseTokenizer
+    def create_new(cls, config: ConfigMetaCAT, base_tokenizer: BaseTokenizer,
+                   tknzer_preprocessor: TokenizerPreprocessor = None
                    ) -> 'MetaCATAddon':
         """Factory method to create a new MetaCATAddon instance."""
         tokenizer = init_tokenizer(config)
+        if tknzer_preprocessor is not None:
+            tknzer_preprocessor(tokenizer)
         meta_cat = MetaCAT(tokenizer, embeddings=None, config=config)
         return cls(config, base_tokenizer, meta_cat)
 

--- a/medcat2/config/config_meta_cat.py
+++ b/medcat2/config/config_meta_cat.py
@@ -198,6 +198,7 @@ class Model(DirtiableBaseModel):
     class Config:
         extra = 'allow'
         validate_assignment = True
+        protected_namespaces = ()
 
 
 class Train(DirtiableBaseModel):

--- a/medcat2/tokenizing/regex_impl/tokenizer.py
+++ b/medcat2/tokenizing/regex_impl/tokenizer.py
@@ -183,9 +183,10 @@ class Entity:
         # NOTE: registering for document since that should be constant
         # whereas the entities may be created and recreated
         # it'll map the entity start and end index to the value
-        def_val = defaultdict(lambda: def_val)
+        def_val_doc = defaultdict(lambda: def_val)
         Document.register_addon_path(
-            f"{cls.ENTITY_INFO_PREFIX}{path}", def_val=def_val, force=force)
+            f"{cls.ENTITY_INFO_PREFIX}{path}", def_val=def_val_doc,
+            force=force)
 
     def __iter__(self) -> Iterator[MutableToken]:
         for tkn in self._doc._tokens[self.start_index: self.end_index]:

--- a/medcat2/tokenizing/regex_impl/tokenizer.py
+++ b/medcat2/tokenizing/regex_impl/tokenizer.py
@@ -183,7 +183,7 @@ class Entity:
         # NOTE: registering for document since that should be constant
         # whereas the entities may be created and recreated
         # it'll map the entity start and end index to the value
-        def_val_doc = defaultdict(lambda: def_val)
+        def_val_doc: dict = defaultdict(lambda: def_val)
         Document.register_addon_path(
             f"{cls.ENTITY_INFO_PREFIX}{path}", def_val=def_val_doc,
             force=force)

--- a/tests/tokenizing/regex_impl/test_tokenizer.py
+++ b/tests/tokenizing/regex_impl/test_tokenizer.py
@@ -32,3 +32,61 @@ class TokenizerTests(TestCase):
     def test_doc_has_correct_tokens(self):
         self.assertEqual([tkn.base.text for tkn in self.tokens],
                          self.EXP_TOKENS)
+
+
+class EntitySimpleAddonDataTests(TestCase):
+    EXAMPLE_TEXT = "Some example text"
+    ADDON_PATH = "test_time_addon"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tokenizer = tokenizer.RegexTokenizer()
+        cls.tokenizer.get_entity_class().register_addon_path(cls.ADDON_PATH)
+
+    def _make_tokens_entities(self):
+        num_tokens = len(self.doc)
+        for ent_num in range(num_tokens):
+            ent = self.doc[ent_num: ent_num + 1]
+            self.doc.all_ents.append(ent)
+
+    def _set_single_entity_data(self, ent_num: int,
+                                entity: tokenizer.MutableEntity):
+        entity.set_addon_data(self.ADDON_PATH, ent_num)
+
+    def _get_expected_data(self, ent_num: int,
+                           entity: tokenizer.MutableEntity):
+        return ent_num
+
+    def _set_per_entity_data(self):
+        for ent_num, entity in enumerate(self.doc.all_ents):
+            self._set_single_entity_data(ent_num, entity)
+
+    def setUp(self):
+        self.doc = self.tokenizer(self.EXAMPLE_TEXT)
+        # add all tokens as entities
+        self._make_tokens_entities()
+        # set addon data for all tokens
+        self._set_per_entity_data()
+
+    def test_can_get_addon_data(self):
+        self.assertGreater(len(self.doc.all_ents), 0)
+        for ent_num, entity in enumerate(self.doc.all_ents):
+            with self.subTest(f"Entity {ent_num}: {entity}"):
+                data_val = entity.get_addon_data(self.ADDON_PATH)
+                self.assertEqual(data_val, self._get_expected_data(
+                    ent_num, entity))
+
+
+class EntityComplexAddonTests(EntitySimpleAddonDataTests):
+    ADDON_PATH = "complex_data_path"
+
+    def _set_single_entity_data(self, ent_num: int,
+                                entity: tokenizer.MutableEntity):
+        if (data := entity.get_addon_data(self.ADDON_PATH)) is not None:
+            data[len(data)] = ent_num
+        else:
+            entity.set_addon_data(self.ADDON_PATH, {0: ent_num})
+
+    def _get_expected_data(self, ent_num: int,
+                           entity: tokenizer.MutableEntity):
+        return {0: ent_num}


### PR DESCRIPTION
The previous MetaCAT init procedure (for a new MetaCAT) had an issue. It didn't allow one to pre-process (e.g train) a tokenizer. And because of that, when initialising a BPE tokenizer the vocab size would be 0. And nothing would work further down the stream since embeddings would be initialised based on that value. Setting these later in MetaCAT wouldn't have helped either.

So this PR fixes that by allowing one to pass a preprocessor to `MetaCAT.create_new` that would act on the tokenizer before everything else is initialised.