### PR TITLE
CU-869926zcv Fix minor issues discoverd from wwc conversion

### DIFF
--- a/medcat2/utils/legacy/convert_cdb.py
+++ b/medcat2/utils/legacy/convert_cdb.py
@@ -65,6 +65,7 @@ NAME2KEYS = {'name2cuis', 'name2cuis2status', 'name2count_train',
 CUI2KEYS = {'cui2names', 'cui2snames', 'cui2context_vectors',
             'cui2count_train', 'cui2info', 'cui2tags', 'cui2type_ids',
             'cui2preferred_name', 'cui2average_confidence', }
+CUI2KEYS_OPTIONAL = {"cui2info", }
 TO_RENAME = {'vocab': 'token_counts'}
 
 
@@ -105,6 +106,11 @@ _DEFAULT_SNOMED_TYPE_ID2NAME = {
 def _add_cui_info(cdb: CDB, data: dict) -> CDB:
     all_cuis = set()
     for key in CUI2KEYS:
+        if key in CUI2KEYS_OPTIONAL and key not in data:
+            logger.info(
+                "Optional key to be converted was not found in target "
+                "data: %s. Ignoring", key)
+            continue
         ccuis = data[key].keys()
         logger.debug("Adding %d cuis based on '%s", len(ccuis), key)
         all_cuis.update(ccuis)

--- a/medcat2/utils/legacy/convert_config.py
+++ b/medcat2/utils/legacy/convert_config.py
@@ -23,6 +23,8 @@ CONFIG_MOVE = {
     'general.spacy_model': 'general.nlp.modelname',
     'general.spacy_disabled_components': 'general.nlp.disabled_components',
 }
+CONFIG_MOVE_OPTIONAL = {
+    "version.description", "version.id", "version.ontology"}
 MOVE_WITH_REMOVES = {
     'general': {'checkpoint',  # TODO: Start supporitn checkpoints again
                 'spacy_model', 'spacy_disabled_components', 'usage_monitor'},
@@ -62,6 +64,11 @@ def get_val_and_parent_model(old_data: Optional[dict],
         else:
             name = ''
         if val is not None:
+            if path in CONFIG_MOVE_OPTIONAL and cname not in val:
+                logger.warning(
+                    "Optional path '%s' not found in old config. Ignoring",
+                    path)
+                break
             val = val[cname]
     return val, target_model
 

--- a/medcat2/utils/legacy/convert_config.py
+++ b/medcat2/utils/legacy/convert_config.py
@@ -162,9 +162,10 @@ def get_config_from_nested_dict(old_data: dict) -> Config:
     # but we now default to regex
     cnf.general.nlp.provider = 'spacy'
     cnf = _make_changes(cnf, old_data)
-    if cnf.general.nlp.modelname == 'spacy_model':
+    if cnf.general.nlp.modelname in ('spacy_model', 'en_core_sci_md'):
         logger.info("Fixing spacy model. "
-                    "Moving from 'spacy_model' to 'en_core_web_md'!")
+                    "Moving from '%s' to 'en_core_web_md'!",
+                    cnf.general.nlp.modelname)
         cnf.general.nlp.modelname = 'en_core_web_md'
     return cnf
 


### PR DESCRIPTION
Found a few minor issues while converting `working_with_cogstack` to v2.
These affected older style data during legacy conversion.

The changes:
- Allow ignoring `cdb.cui2info` in legacy CDB if not present
- Allow ignoring `config.versioning` stuff if not present in legacy Config
- Use `en_core_web_md` instead of legacy / unavailable `en_core_sci_md` where applicable during conversion