### PR TITLE
CU-86993z37f update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [ # Optional
   "tqdm>=4.64,<5.0",
   "xxhash>=3.5.0,<4.0",
   "pydantic>2.0",
+  "typing_extensions",
   # TODO - others
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ deid = [
   "datasets>=2.2.2,<3.0.0",
   "transformers>=4.41.0,<5.0", # avoid major bump
   "scikit-learn>=1.1.3,<2.0",
+  "torch>=2.4.0,<3.0",
   "scipy",
 ]
 rel_cat = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,8 @@ dict_ner = [
 ]
 deid = [
   "datasets>=2.2.2,<3.0.0",
-  "transformers>=4.41.0,<5.0" # avoid major bump
+  "transformers>=4.41.0,<5.0", # avoid major bump
+  "scikit-learn>=1.1.3,<2.0",
 ]
 test = []  # TODO - list
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ spacy = [
   "spacy<3.8.4; python_version == '3.9'"
 ]
 meta_cat = [
+  "transformers>=4.41.0,<5.0", # avoid major bump
   "peft>0.8.2,<1.0",
   "torch>=2.4.0,<3.0",
   "scikit-learn>=1.1.3,<2.0",
@@ -99,6 +100,9 @@ deid = [
   "transformers>=4.41.0,<5.0", # avoid major bump
   "scikit-learn>=1.1.3,<2.0",
   "scipy",
+]
+rel_cat = [
+  "transformers>=4.41.0,<5.0", # avoid major bump
 ]
 test = []  # TODO - list
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,8 @@ deid = [
 ]
 rel_cat = [
   "transformers>=4.41.0,<5.0", # avoid major bump
+  "scikit-learn>=1.1.3,<2.0",
+  "torch>=2.4.0,<3.0",
 ]
 test = []  # TODO - list
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ meta_cat = [
   "peft>0.8.2,<1.0",
   "torch>=2.4.0,<3.0",
   "scikit-learn>=1.1.3,<2.0",
+  "scipy",
 ]
 dict_ner = [
   "pyahocorasick>=2.1.0,<3.0"
@@ -97,6 +98,7 @@ deid = [
   "datasets>=2.2.2,<3.0.0",
   "transformers>=4.41.0,<5.0", # avoid major bump
   "scikit-learn>=1.1.3,<2.0",
+  "scipy",
 ]
 test = []  # TODO - list
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [ # Optional
   "tqdm>=4.64,<5.0",
   "xxhash>=3.5.0,<4.0",
   "pydantic>2.0",
-  "typing_extensions",
+  "typing-extensions",
   # TODO - others
 ]
 


### PR DESCRIPTION
Some dependencies were being installed and used as transitive dependencies, but hadn't been specified explicitly.

Also, some dependencies were used by sub-parts, but not specified as requirements for those parts.