### PR TITLE
CU-86994t45r RelCAT conversion

### DIFF
--- a/medcat2/components/addons/relation_extraction/base_component.py
+++ b/medcat2/components/addons/relation_extraction/base_component.py
@@ -145,7 +145,13 @@ class RelExtrBaseComponent:
 
         relcat_config = ConfigRelCAT.load(
             load_path=pretrained_model_name_or_path)
+        return cls.from_relcat_config(
+            relcat_config, pretrained_model_name_or_path)
 
+    @classmethod
+    def from_relcat_config(cls, relcat_config: ConfigRelCAT,
+                           pretrained_model_name_or_path: str = './'
+                           ) -> 'RelExtrBaseComponent':
         model_config = RelExtrBaseConfig.load(
             pretrained_model_name_or_path=pretrained_model_name_or_path,
             relcat_config=relcat_config)

--- a/medcat2/components/addons/relation_extraction/rel_cat.py
+++ b/medcat2/components/addons/relation_extraction/rel_cat.py
@@ -61,6 +61,7 @@ class RelCATAddon(AddonComponent):
                       load_path: str) -> 'RelCATAddon':
         """Factory method to load an existing RelCAT addon from disk."""
         rc = RelCAT.load(load_path)
+        # set the correct base tokenizer and redo data paths
         rc.base_tokenizer = base_tokenizer
         rc._init_data_paths()
         return cls(cnf, rc)

--- a/medcat2/components/addons/relation_extraction/rel_cat.py
+++ b/medcat2/components/addons/relation_extraction/rel_cat.py
@@ -43,17 +43,15 @@ class RelCATAddon(AddonComponent):
     config: ConfigRelCAT
 
     def __init__(self, config: ConfigRelCAT,
-                 base_tokenizer: BaseTokenizer,
                  rel_cat: "RelCAT"):
         self.config = config
-        self.base_tokenizer = base_tokenizer
         self._rel_cat = rel_cat
 
     @classmethod
     def create_new(cls, config: ConfigRelCAT, base_tokenizer: BaseTokenizer,
                    cdb: CDB) -> 'RelCATAddon':
         """Factory method to create a new MetaCATAddon instance."""
-        return cls(config, base_tokenizer,
+        return cls(config,
                    RelCAT(base_tokenizer, cdb, config=config, init_model=True))
 
     @classmethod
@@ -62,7 +60,7 @@ class RelCATAddon(AddonComponent):
                       cdb: CDB,
                       load_path: str) -> 'RelCATAddon':
         """Factory method to load an existing RelCAT addon from disk."""
-        return cls(cnf, base_tokenizer, RelCAT.load(load_path))
+        return cls(cnf, RelCAT.load(load_path))
 
     def serialise_to(self, folder_path: str) -> None:
         os.mkdir(folder_path)
@@ -233,6 +231,7 @@ class RelCAT:
             component.relcat_config.general.device != "cpu" else "cpu")
 
         rel_cat = RelCAT(
+            # NOTE: this is a throaway tokenizer just for registrations
             create_tokenizer(cdb.config.general.nlp.provider),
             cdb=cdb, config=component.relcat_config, task=component.task)
         rel_cat.device = device
@@ -884,7 +883,8 @@ class RelCAT:
             Doc: spacy doc with the relations.
         """
         # NOTE: This runs not an empty language, but the specified one
-        doc = self.base_tokenizer(text)
+        base_tokenizer = create_tokenizer(self.cdb.config.general.nlp.provider)
+        doc = base_tokenizer(text)
 
         for ann in annotations:
             tkn_idx = []
@@ -892,7 +892,7 @@ class RelCAT:
                 end_char = word.base.char_index + len(word.base.text)
                 if end_char <= ann['end'] and end_char > ann['start']:
                     tkn_idx.append(ind)
-            entity = self.base_tokenizer.create_entity(
+            entity = base_tokenizer.create_entity(
                 doc, min(tkn_idx), max(tkn_idx) + 1, label=ann["value"])
             entity.cui = ann["cui"]
             doc.all_ents.append(entity)

--- a/medcat2/components/addons/relation_extraction/rel_cat.py
+++ b/medcat2/components/addons/relation_extraction/rel_cat.py
@@ -60,7 +60,10 @@ class RelCATAddon(AddonComponent):
                       cdb: CDB,
                       load_path: str) -> 'RelCATAddon':
         """Factory method to load an existing RelCAT addon from disk."""
-        return cls(cnf, RelCAT.load(load_path))
+        rc = RelCAT.load(load_path)
+        rc.base_tokenizer = base_tokenizer
+        rc._init_data_paths()
+        return cls(cnf, rc)
 
     def serialise_to(self, folder_path: str) -> None:
         os.mkdir(folder_path)

--- a/medcat2/pipeline/pipeline.py
+++ b/medcat2/pipeline/pipeline.py
@@ -18,6 +18,7 @@ from medcat2.cdb import CDB
 from medcat2.config import Config
 from medcat2.config.config import ComponentConfig
 from medcat2.config.config_meta_cat import ConfigMetaCAT
+from medcat2.config.config_rel_cat import ConfigRelCAT
 from medcat2.utils.default_args import (set_tokenizer_defaults,
                                         set_components_defaults,
                                         set_addon_defaults)
@@ -207,11 +208,18 @@ class Pipeline:
             comp_name, subname = key
             if comp_name != cnf.comp_name:
                 continue
-            if not isinstance(cnf, ConfigMetaCAT):
+            if not isinstance(cnf, (ConfigMetaCAT, ConfigRelCAT)):
                 raise UnkownAddonConfig(cnf, ConfigMetaCAT)
-            if cnf.general.category_name == subname:
-                del loaded_addon_component_paths[key]
-                return folder
+            if isinstance(cnf, ConfigMetaCAT):
+                if cnf.general.category_name == subname:
+                    del loaded_addon_component_paths[key]
+                    return folder
+            elif isinstance(cnf, ConfigRelCAT):
+                if subname == 'rel_cat':
+                    # NOTE: there can currently only ever be 1 RelCAT
+                    #       this wasn't a limitation in v1
+                    del loaded_addon_component_paths[key]
+                    return folder
         return None
 
     def _load_addon(self, cnf: ComponentConfig, load_from: str

--- a/medcat2/utils/legacy/conversion_all.py
+++ b/medcat2/utils/legacy/conversion_all.py
@@ -12,6 +12,7 @@ from medcat2.utils.legacy.convert_cdb import get_cdb_from_old
 from medcat2.utils.legacy.convert_config import get_config_from_old
 from medcat2.utils.legacy.convert_vocab import get_vocab_from_old
 from medcat2.utils.legacy.convert_meta_cat import get_meta_cat_from_old
+from medcat2.utils.legacy.convert_rel_cat import get_rel_cat_from_old
 from medcat2.utils.legacy.convert_deid import get_trf_ner_from_old
 from medcat2.utils.legacy.helpers import fix_subnames
 
@@ -89,6 +90,18 @@ class Converter:
         ]
         for mc in meta_cats:
             cat.add_addon(mc)
+
+        # RelCATs
+        rel_cats = [
+            get_rel_cat_from_old(
+                cdb,
+                os.path.join(self.old_model_folder, subfolder),
+                cat._pipeline.tokenizer)
+            for subfolder in os.listdir(self.old_model_folder)
+            if subfolder.startswith("rel_")
+        ]
+        for rc in rel_cats:
+            cat.add_addon(rc)
 
         # DeID / TransformersNER
         trf_ners = [

--- a/medcat2/utils/legacy/convert_rel_cat.py
+++ b/medcat2/utils/legacy/convert_rel_cat.py
@@ -1,0 +1,81 @@
+import os
+import json
+import logging
+
+import torch
+
+from medcat2.cdb import CDB
+from medcat2.components.addons.relation_extraction.rel_cat import (
+    RelCAT, RelCATAddon)
+from medcat2.components.addons.relation_extraction.base_component import (
+    RelExtrBaseComponent)
+from medcat2.config.config_rel_cat import ConfigRelCAT
+from medcat2.tokenizing.tokenizers import BaseTokenizer, create_tokenizer
+from medcat2.utils.legacy.convert_meta_cat import _fix_old_style_cnf
+
+
+logger = logging.getLogger(__name__)
+
+
+def _load_legacy(cdb: CDB, base_tokenizer: BaseTokenizer,
+                 config: ConfigRelCAT, save_dir_path: str) -> RelCAT:
+    # tokenizer: Optional[TokenizerWrapperBase] = None
+    # Load tokenizer
+    # tokenizer = load_tokenizer(config, save_dir_path)
+
+    # Create rel_cat
+    # rel_cat = RelCAT(tokenizer=tokenizer, embeddings=None, config=config)
+    component = RelExtrBaseComponent.from_relcat_config(config, save_dir_path)
+    device = torch.device(
+        "cuda" if torch.cuda.is_available() and
+        component.relcat_config.general.device != "cpu" else "cpu")
+
+    rel_cat = RelCAT(
+        base_tokenizer, cdb=cdb,
+        config=component.relcat_config, task=component.task)
+    rel_cat.device = device
+    rel_cat.component = component
+    return rel_cat
+
+
+def load_cnf(cnf_path: str) -> ConfigRelCAT:
+    with open(cnf_path) as f1:
+        data = json.load(f1)
+    data = _fix_old_style_cnf(data)
+    cnf = ConfigRelCAT.model_validate(data)
+    cnf.comp_name = RelCATAddon.addon_type
+    return cnf
+
+
+def get_rel_cat_from_old(cdb: CDB, old_path: str, tokenizer: BaseTokenizer
+                         ) -> RelCATAddon:
+    """Convert a v1 RelCAT folder to a v2 RelCAT.
+
+    Args:
+        cdb (CDB): The base CDB.
+        old_path (str): The v1 RelCAT file path.
+        tokenizer (BaseTokenizer): The tokenizer.
+
+    Returns:
+        RelCATAddon: The v2 RelCAT.
+    """
+    cnf = load_cnf(os.path.join(old_path, "config.json"))
+    rel_cat = _load_legacy(cdb, tokenizer, cnf, old_path)
+    addon = RelCATAddon.create_new(cnf, tokenizer, rel_cat.cdb)
+    addon._rel_cat = rel_cat
+    return addon
+
+
+if __name__ == "__main__":
+    import sys
+    from medcat2.config import Config
+    cdb = CDB(Config())
+    cdb.config.general.nlp.provider = 'spacy'
+    rc = get_rel_cat_from_old(cdb, sys.argv[1],
+                              create_tokenizer(
+                                  "spacy",
+                                  "en_core_web_md",  # model name
+                                  cdb.config.general.nlp.disabled_components,
+                                  False,  # diacritics
+                                  cdb.config.preprocessing.max_document_length
+                                  ))

--- a/tests/components/addons/relation_extraction/test_rel_cat_in_model_pack.py
+++ b/tests/components/addons/relation_extraction/test_rel_cat_in_model_pack.py
@@ -1,0 +1,92 @@
+import os
+
+from medcat2.components.addons.relation_extraction import rel_cat
+from medcat2.utils.legacy.convert_rel_cat import get_rel_cat_from_old
+from medcat2.tokenizing.tokenizers import create_tokenizer
+from medcat2.storage.serialisers import AvailableSerialisers
+from medcat2.cat import CAT
+from medcat2.cdb import CDB
+from medcat2.config import Config
+
+import unittest
+import tempfile
+import shutil
+from urllib import request as url_request
+
+from .... import UNPACKED_EXAMPLE_MODEL_PACK_PATH
+
+
+S3_RELCAT_PATH = (
+    "https://cogstack-medcat-example-models.s3.eu-west-2.amazonaws.com/"
+    "medcat-example-models/ade_relcat_model_smaller.zip")
+
+
+class LoadedRelCATTests(unittest.TestCase):
+    SER_TYPE = AvailableSerialisers.dill
+    temp_dir = tempfile.TemporaryDirectory()
+    _model_pack_folder_name = 'rel_cat_model_pack'
+    # model_pack_path = os.path.join(temp_dir.name, _model_pack_folder_name)
+    _rel_cat_zip_path = os.path.join(temp_dir.name, "ade_relcat_model.zip")
+    _unpacked_v1_rel_cat_path = os.path.join(temp_dir.name, "ade_relcat_model")
+    # model_rel_cat_path = os.path.join(model_pack_path, "addon_rel_cat.DRUG-DOSE_DRUG-AE")
+
+    @classmethod
+    def setUpClass(cls):
+        # # make the model pack path
+        # os.makedirs(cls.model_pack_path)
+        # # copy stuff from unpacked exmaple model pack
+        # for part in os.listdir(UNPACKED_EXAMPLE_MODEL_PACK_PATH):
+        #     from_path = os.path.join(
+        #         UNPACKED_EXAMPLE_MODEL_PACK_PATH, part)
+        #     to_path = os.path.join(cls.model_pack_path, part)
+        #     if os.path.isdir(from_path):
+        #         shutil.copytree(from_path, to_path)
+        #     else:
+        #         shutil.copy(from_path, to_path)
+        # download, extract, and copy the RelCAT model
+        url_request.urlretrieve(S3_RELCAT_PATH, cls._rel_cat_zip_path)
+        # NOTE: the actual context will be in the ade_relcat_model folder
+        shutil.unpack_archive(cls._rel_cat_zip_path, cls.temp_dir.name)
+        # convert legacy (v1) to v2 RelCAT
+        cnf = Config()
+        cnf.general.nlp.provider = 'spacy'
+        cdb = CDB(cnf)
+        tokenizer = create_tokenizer(
+            "spacy",
+            "en_core_web_md",  # model name
+            cdb.config.general.nlp.disabled_components,
+            False,  # diacritics
+            cdb.config.preprocessing.max_document_length
+            )
+        rc = get_rel_cat_from_old(cdb, cls._unpacked_v1_rel_cat_path, tokenizer)
+        # add to model
+        cat = CAT.load_model_pack(UNPACKED_EXAMPLE_MODEL_PACK_PATH)
+        cat.add_addon(rc)
+        # and save as part of model
+        cls.model_pack_path = cat.save_model_pack(
+            cls.temp_dir.name, cls._model_pack_folder_name).removesuffix(".zip")
+        # serialise(cls.SER_TYPE, rc, cls.model_rel_cat_path)
+        saved_comps_path = os.path.join(cls.model_pack_path, "saved_components")
+        print("IN", saved_comps_path, ":", os.listdir(saved_comps_path))
+        cls.model_rel_cat_path = [os.path.join(saved_comps_path, folder)
+                                  for folder in os.listdir(saved_comps_path)
+                                  if folder.startswith("addon_rel_cat")][0]
+        print("Model RElCAT PATH", cls.model_rel_cat_path)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.temp_dir.cleanup()
+
+    def test_can_load_rel_cat(self):
+        rc = rel_cat.RelCAT.load(self.model_rel_cat_path)
+        self.assertIsInstance(rc, rel_cat.RelCAT)
+
+    def assert_has_rel_cat(self, cat: CAT):
+        self.assertTrue(any(isinstance(comp, rel_cat.RelCATAddon)
+                            for comp in cat._pipeline.iter_addons()))
+
+
+    def test_can_load_model_pack(self):
+        cat = CAT.load_model_pack(self.model_pack_path)
+        self.assertIsInstance(cat, CAT)
+        self.assert_has_rel_cat(cat)

--- a/tests/utils/legacy/test_convert_rel_cat.py
+++ b/tests/utils/legacy/test_convert_rel_cat.py
@@ -1,0 +1,6 @@
+# NOTE: this file is here just to indicate that these tests are in fact run
+#       but they're run in:
+#       tests.components.addons.relation_extraction.test_rel_cat_in_model_pack
+#       that is because they involve downloading a (relatively) large RelCAT model (v1),
+#       converting it to v2, adding to a model pack, and subsequently saving it
+#       as part of the model pack


### PR DESCRIPTION
Adds RelCAT conversion.

Tests are done within:
```
tests.components.addons.relation_extraction.test_rel_cat_in_model_pack
```
They involve downloading a RelCAT model from S3 (it's 250MB or so), converting it, adding to model pack, and saving model pack with it. And subsequently loading both the RelCAT model separately as well as loading the whole model pack and ensuring it has a RelCAT addon.