### PR TITLE
CU-8699cdpfq allow including spacy model

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ extensions = [
 ]
 
 autoapi_type = 'python'
-autoapi_dirs = ['../medcat2']
+autoapi_dirs = ['../medcat']
 autodoc_typehints = 'description'
 autoapi_template_dir = '_templates/autoapi_templates'
 

--- a/medcat/tokenizing/spacy_impl/tokenizers.py
+++ b/medcat/tokenizing/spacy_impl/tokenizers.py
@@ -51,16 +51,18 @@ class SpacyTokenizer(BaseTokenizer):
         self._spacy_model_name = os.path.basename(
             spacy_model_name).removeprefix(TOKENIZER_PREFIX)
         if self.load_internals_from(spacy_model_name):
-            # NOTE: already set self._nlp
+            # i.e has something to load from path
             pass
         else:
-            ensure_spacy_model(spacy_model_name)
-            if stopwords is not None:
-                lang_str = os.path.basename(spacy_model_name).split('_', 1)[0]
-                cls = spacy.util.get_lang_class(lang_str)
-                cls.Defaults.stop_words = set(stopwords)
-            self._nlp = spacy.load(spacy_model_name,
-                                   disable=spacy_disabled_components)
+            # no file provided, ensure the model is available
+            ensure_spacy_model(self._spacy_model_name)
+            spacy_model_name = self._spacy_model_name
+        if stopwords is not None:
+            lang_str = os.path.basename(spacy_model_name).split('_', 1)[0]
+            cls = spacy.util.get_lang_class(lang_str)
+            cls.Defaults.stop_words = set(stopwords)
+        self._nlp = spacy.load(spacy_model_name,
+                               disable=spacy_disabled_components)
         self._nlp.tokenizer = tokenizer_getter(self._nlp, use_diacritics)
         self._nlp.max_length = max_document_length
 
@@ -118,8 +120,4 @@ class SpacyTokenizer(BaseTokenizer):
         return subfolder
 
     def load_internals_from(self, folder_path: str) -> bool:
-        if not os.path.exists(folder_path):
-            return False
-        logger.debug("Loading spacy model from '%s'", folder_path)
-        self._nlp = spacy.load(folder_path)
-        return True
+        return os.path.exists(folder_path):

--- a/medcat/tokenizing/spacy_impl/tokenizers.py
+++ b/medcat/tokenizing/spacy_impl/tokenizers.py
@@ -120,4 +120,4 @@ class SpacyTokenizer(BaseTokenizer):
         return subfolder
 
     def load_internals_from(self, folder_path: str) -> bool:
-        return os.path.exists(folder_path):
+        return os.path.exists(folder_path)

--- a/medcat/tokenizing/tokenizers.py
+++ b/medcat/tokenizing/tokenizers.py
@@ -1,4 +1,4 @@
-from typing import Protocol, Type, Any, Callable
+from typing import Protocol, Type, Any, Callable, runtime_checkable
 import logging
 
 from medcat.config import Config
@@ -8,6 +8,9 @@ from medcat.utils.registry import Registry
 
 
 logger = logging.getLogger(__name__)
+
+
+TOKENIZER_PREFIX = "tokenizer_internals_"
 
 
 class BaseTokenizer(Protocol):
@@ -66,6 +69,38 @@ class BaseTokenizer(Protocol):
 
         Returns:
             Type[MutableEntity]: The entity class.
+        """
+        pass
+
+
+@runtime_checkable
+class SaveableTokenizer(Protocol):
+
+    def save_internals_to(self, folder_path: str) -> str:
+        """Save tokenizer internals to specified folder.
+
+        The returning folder's basename should start with `TOKENIZER_PREFIX`.
+
+        Args:
+            folder_path (str): The folder to use for the internals.
+
+        Returns:
+            str: The subfolder the internals were saved to.
+        """
+
+    def load_internals_from(self, folder_path: str) -> bool:
+        """Attempt to load internals from a folder path.
+
+        If the specified folder exists, internals will be loaded.
+        If the folder doesn't exist, nothing will be loaded.
+
+        The given folder's basename should start with `TOKENIZER_PREFIX`.
+
+        Args:
+            folder_path (str): The path to the folder to load internals from.
+
+        Returns:
+            bool: Whether the loading was successful.
         """
         pass
 

--- a/medcat/trainer.py
+++ b/medcat/trainer.py
@@ -4,7 +4,7 @@ from itertools import chain, repeat, islice
 from tqdm import trange
 
 from medcat.tokenizing.tokens import (MutableDocument, MutableEntity,
-                                       MutableToken)
+                                      MutableToken)
 from medcat.cdb import CDB
 from medcat.config.config import General, Preprocessing, CDBMaker
 from medcat.utils.config_utils import temp_changed_config

--- a/medcat/utils/usage_monitoring.py
+++ b/medcat/utils/usage_monitoring.py
@@ -113,12 +113,21 @@ class UsageMonitor:
         # (i.e exit call)
         try:
             self._flush_logs()
-        except FileNotFoundError as err:
+        except FileNotFoundError:
             if not _in_test():
-                raise err
+                raise
+        except NameError as err:
+            if not _says_open_not_available(err):
+                raise
+
+
+# NOTE: at termination time, open is not available
+#       while this isn't great, there's nothing we can do
+def _says_open_not_available(err: NameError) -> bool:
+    return "name 'open' is not defined" in str(err)
 
 
 # NOTE: only relevant to flushing at deletion time
 #       should not be used elsewhere
-def _in_test():
+def _in_test() -> bool:
     return any(mod in sys.modules for mod in ("unittest", "pytest"))

--- a/medcat/utils/usage_monitoring.py
+++ b/medcat/utils/usage_monitoring.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Union, Callable
 import platform
 import logging
+import sys
 
 from medcat.config.config import UsageMonitor as UsageMonitorConfig
 
@@ -110,4 +111,14 @@ class UsageMonitor:
     def __del__(self):
         # fail safe for when buffer is non-empty upon application stop
         # (i.e exit call)
-        self._flush_logs()
+        try:
+            self._flush_logs()
+        except FileNotFoundError as err:
+            if not _in_test():
+                raise err
+
+
+# NOTE: only relevant to flushing at deletion time
+#       should not be used elsewhere
+def _in_test():
+    return any(mod in sys.modules for mod in ("unittest", "pytest"))

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -463,7 +463,8 @@ class MethodSpy:
         #     print((_args, _kwargs))
         #     print('->', (args, kwargs) == (_args, _kwargs))
         # print("overall...", (args, kwargs) in self.call_args)
-        assert (args, kwargs) in self.call_args
+        assert (args, kwargs) in self.call_args, (
+            f"No such args for, {self._original_method}")
 
     def assert_called_once_with(self, *args, **kwargs):
         # print("Is module?", self.is_module, "@", self._original_method)
@@ -515,7 +516,9 @@ class CATWithDocAddonSpacyTests(CATWithDocAddonTests):
                 model = cat.CAT.load_model_pack(self.saved_model_path)
         self.assertIsInstance(model, cat.CAT)
         mock_load_internal.assert_called_once_with(self.saved_spacy_path)
-        mock_load.assert_called_once_with(self.saved_spacy_path)
+        mock_load.assert_called_once_with(
+            self.saved_spacy_path,
+            disable=self.cat.config.general.nlp.disabled_components)
 
 
 class CATWithEntityAddonTests(CATIncludingTests):

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -429,16 +429,13 @@ class MethodSpy:
         self.call_results = []
         self._patcher = None
         self._original_method = getattr(obj, method_name)
-        print("INIT w", self._original_method)
 
     def __enter__(self):
         def wrapper(*args, **kwargs):
             self.call_args.append((args, kwargs))
             if self.is_module:
-                print("Module-based wrap")
                 result = self._original_method(*args, **kwargs)
             else:
-                print("Object-based wrap")
                 result = self._original_method(self.obj, *args, **kwargs)
             self.call_results.append(result)
             return result
@@ -447,34 +444,19 @@ class MethodSpy:
             self.obj, self.method_name, side_effect=wrapper
         )
         self._patcher.start()
-        print("Spying for", self._original_method,
-              'with', getattr(self.obj, self.method_name))
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self._patcher.stop()
 
     def assert_called_with(self, *args, **kwargs):
-        # print("ARGS")
-        # print((args, kwargs))
-        # print("VS on of ...")
-        # for _args, _kwargs in self.call_args:
-        #     print("=="*15)
-        #     print((_args, _kwargs))
-        #     print('->', (args, kwargs) == (_args, _kwargs))
-        # print("overall...", (args, kwargs) in self.call_args)
         assert (args, kwargs) in self.call_args, (
             f"No such args for, {self._original_method}")
 
     def assert_called_once_with(self, *args, **kwargs):
-        # print("Is module?", self.is_module, "@", self._original_method)
-        # print("CALL ARGS", self.call_args,
-        #       '\n\t', len(self.call_args), '->', len(self.call_args) == 1)
         assert len(self.call_args) == 1
         self.assert_called_with(
             *args, **kwargs)
-        # print("Return assert", rval)
-        # assert rval, f"For {self._original_method}"
 
     def assert_returned(self, ret_val):
         assert ret_val in self.call_results
@@ -491,8 +473,6 @@ class CATWithDocAddonSpacyTests(CATWithDocAddonTests):
             cls._save_folder.name, make_archive=False)
         # NOTE: that has changed config
         cls.saved_spacy_path = cls.cat.config.general.nlp.modelname
-        print("SAVED TO", cls.saved_model_path)
-        print("Spacy @", cls.saved_spacy_path)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
So far, the `spaCy` model wasn't saved alongside model packs.
That was because the overall restructure means that the codebase is decoupled from `spaCy` and thus the saving was omitted in a general sense.

In many "regular" use cases the `spaCy` model can be downloaded dynamically. And that only ever needs to be done once.
However, in a (semi) air gapped situation (such as that in hospitals) downloading the model dynamically may not be possible. As such, the spacy model needs to ship with the model pack.

So what this PR does:
- Creates a new `Protocol` alongside `Tokenizer` (`SaveableTokenizer`)
- If the used tokenizer follows `SaveableTokenizer`, it is saved along the model at save time
- When loaded, the on disk spacy model is loaded if/when possible