### PR TITLE
CU-8699dexbr Improve Meta annotation access

### DIFF
--- a/medcat/components/addons/meta_cat/meta_cat.py
+++ b/medcat/components/addons/meta_cat/meta_cat.py
@@ -44,6 +44,12 @@ class MedCATTrainerExportDocument(TypedDict):
     value: str
 
 
+class MetaAnnotationValue(TypedDict):
+    name: str
+    value: str
+    confidence: float
+
+
 TokenizerPreprocessor = Optional[
     Callable[[Optional[TokenizerWrapperBase]], None]]
 
@@ -148,7 +154,7 @@ class MetaCATAddon(AddonComponent):
         return True
 
     def get_output_key_val(self, ent: MutableEntity
-                           ) -> tuple[str, dict[str, Any]]:
+                           ) -> tuple[str, dict[str, MetaAnnotationValue]]:
         # NOTE: In case of multiple MetaCATs, this will be called
         #       once for each MetaCAT and will get the same value.
         #       But it shouldn't be too much of an issue.
@@ -186,6 +192,11 @@ class MetaCATAddon(AddonComponent):
             return self._mc.get_hash()
         else:
             return 'No-model'
+
+
+def get_meta_annotations(entity: MutableEntity
+                         ) -> dict[str, MetaAnnotationValue]:
+    return entity.get_addon_data(_META_ANNS_PATH)
 
 
 class MetaCAT(AbstractSerialisable):

--- a/tests/components/addons/meta_cat/test_meta_cat.py
+++ b/tests/components/addons/meta_cat/test_meta_cat.py
@@ -120,9 +120,9 @@ class MetaCATWithCATTests(MetaCATBaseTests):
         # NOTE: ideally, I'd use cat._doc_to_out
         #       but for same text should be fine either way
         ents = self.cat.get_entities(text)['entities']
-        self.assertEqual(len(doc.final_ents), len(ents))
+        self.assertEqual(len(doc.linked_ents), len(ents))
         self.assertGreater(len(ents), 0)
-        for num, ent in enumerate(doc.final_ents):
+        for num, ent in enumerate(doc.linked_ents):
             with self.subTest(f"Entity {num}"):
                 self.assertEqual(
                     meta_cat.get_meta_annotations(ent),

--- a/tests/components/addons/meta_cat/test_meta_cat.py
+++ b/tests/components/addons/meta_cat/test_meta_cat.py
@@ -113,3 +113,17 @@ class MetaCATWithCATTests(MetaCATBaseTests):
                 self.assertIn(meta_cat.MetaCATAddon.output_key, ent)
                 val = ent[meta_cat.MetaCATAddon.output_key]
                 self.assertIn(self.meta_cat.name, val)
+
+    def test_manual_meta_anns_are_same(self):
+        text = "This is a fit text for rich and chronic disease like fittest."
+        doc = self.cat(text)
+        # NOTE: ideally, I'd use cat._doc_to_out
+        #       but for same text should be fine either way
+        ents = self.cat.get_entities(text)['entities']
+        self.assertEqual(len(doc.final_ents), len(ents))
+        self.assertGreater(len(ents), 0)
+        for num, ent in enumerate(doc.final_ents):
+            with self.subTest(f"Entity {num}"):
+                self.assertEqual(
+                    meta_cat.get_meta_annotations(ent),
+                    ents[num]["meta_anns"])


### PR DESCRIPTION
This PR imporoves access for Meta Annotations.

Previously you'd need to do:
```
ent: MutableEntity
ent. ent.get_addon_data('meta_cat_meta_anns')
```
Now you can
```
from medcat.components.addons.meta_cat.meta_cat import get_meta_annotations
ent: MutableEntity
get_meta_annotations(entity)
```

For one example it might seem more cumbersome, but for multiple usages it's most likely easier.