### PR TITLE
CU-8699dg1e2 Reduce Duplicate package module names in imports

### DIFF
--- a/medcat/components/addons/meta_cat/__init__.py
+++ b/medcat/components/addons/meta_cat/__init__.py
@@ -1,6 +1,10 @@
 from medcat.utils.import_utils import ensure_optional_extras_installed
 import medcat
 
+from .meta_cat import MetaCAT, MetaCATAddon
+
+
+__all__ = ["MetaCAT", "MetaCATAddon"]
 
 # NOTE: the _ is converted to - automatically
 _EXTRA_NAME = "meta-cat"

--- a/medcat/trainer.py
+++ b/medcat/trainer.py
@@ -319,8 +319,7 @@ class Trainer:
     def _train_meta_cat(self, addon: AddonComponent,
                         data: MedCATTrainerExport) -> None:
         # NOTE: dynamic import to avoid circular imports
-        from medcat.components.addons.meta_cat.meta_cat import (
-            MetaCATAddon)
+        from medcat.components.addons.meta_cat import MetaCATAddon
         _, _, ann0 = next(iter_anns(data))
         if not isinstance(addon, MetaCATAddon):
             raise TypeError(

--- a/medcat/utils/legacy/convert_meta_cat.py
+++ b/medcat/utils/legacy/convert_meta_cat.py
@@ -5,7 +5,7 @@ import logging
 
 import torch
 
-from medcat.components.addons.meta_cat.meta_cat import MetaCAT, MetaCATAddon
+from medcat.components.addons.meta_cat import MetaCAT, MetaCATAddon
 from medcat.components.addons.meta_cat.mctokenizers.tokenizers import (
     TokenizerWrapperBase, load_tokenizer)
 from medcat.config.config_meta_cat import ConfigMetaCAT

--- a/tests/components/addons/meta_cat/test_meta_cat2.py
+++ b/tests/components/addons/meta_cat/test_meta_cat2.py
@@ -5,7 +5,7 @@ from typing import cast
 
 from transformers import AutoTokenizer
 
-from medcat.components.addons.meta_cat.meta_cat import MetaCAT
+from medcat.components.addons.meta_cat import MetaCAT
 from medcat.config.config_meta_cat import ConfigMetaCAT
 from medcat.components.addons.meta_cat.mctokenizers.bert_tokenizer import (
     TokenizerWrapperBERT)

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -15,7 +15,7 @@ from medcat.cdb import CDB
 from medcat.tokenizing.tokens import UnregisteredDataPathException
 from medcat.tokenizing.tokenizers import TOKENIZER_PREFIX
 from medcat.utils.cdb_state import captured_state_cdb
-from medcat.components.addons.meta_cat.meta_cat import MetaCATAddon
+from medcat.components.addons.meta_cat import MetaCATAddon
 from medcat.utils.defaults import AVOID_LEGACY_CONVERSION_ENVIRON
 
 import unittest


### PR DESCRIPTION
This seems to only apply to `medcat.components.addons.meta_cat.meta_cat` currently.

So made that change.

PS:
When #82 is merged, things in there should probably be included as well.