### PR TITLE
CU-8699dyeca: Make sure eval pipeline is created upon DeID conversion

### DIFF
--- a/medcat/utils/legacy/convert_deid.py
+++ b/medcat/utils/legacy/convert_deid.py
@@ -26,4 +26,6 @@ def get_trf_ner_from_old(old_path: str, tokenizer: BaseTokenizer
     config = get_cnf(os.path.join(old_path, exp_cat_config_name))
     config.general.model_name = old_path
     cdb: CDB = get_cdb_from_old(os.path.join(old_path, exp_cdb_name))
-    return TransformersNER.create_new(cdb, tokenizer, config)
+    trf_ner = TransformersNER.create_new(cdb, tokenizer, config)
+    trf_ner._component.create_eval_pipeline()
+    return trf_ner


### PR DESCRIPTION
This should fix the DeID model load from legacy and use right away.

Previously you'd need to convert/save + load up.