### PR TITLE
8699g5q3e Avoid saving usage monitor

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -80,6 +80,7 @@ class CAT(AbstractSerialisable):
             '_trainer',  # recreate if nededed
             '_pipeline',  # need to recreate regardless
             'config',  # will be loaded along with CDB
+            'usage_monitor',  # will be created at startup
         ]
 
     def __call__(self, text: str) -> Optional[MutableDocument]:


### PR DESCRIPTION
Since the usage monitor has the `config`, it'll take quite a bit of space due to it.