### PR TITLE
CU-8699h2yv2: Avoid using pkg_resources (deprecated)

### DIFF
--- a/medcat/utils/envsnapshot.py
+++ b/medcat/utils/envsnapshot.py
@@ -98,7 +98,7 @@ def get_installed_dependencies(include_extras: bool) -> dict[str, str]:
     direct_deps = get_direct_dependencies(include_extras)
     installed_packages: dict[str, str] = {}
     for package in importlib.metadata.distributions():
-        req_name = package.metadata["Name"].lower()
+        req_name = package.metadata["name"].lower()
         if req_name not in direct_deps:
             continue
         installed_packages[req_name] = package.version

--- a/medcat/utils/envsnapshot.py
+++ b/medcat/utils/envsnapshot.py
@@ -125,8 +125,7 @@ def is_dependency_installed(dependency: str) -> bool:
     installed_deps = get_installed_dependencies(True)
     dep_name = dependency.lower()
     dep_name_underscores = dependency.replace("-", "_")
-    dep_name_dashes = dependency.replace("_", "-")
-    options = [dep_name, dep_name_underscores, dep_name_dashes]
+    options = [dep_name, dep_name_underscores]
     return any(option in installed_deps for option in options)
 
 

--- a/medcat/utils/envsnapshot.py
+++ b/medcat/utils/envsnapshot.py
@@ -99,7 +99,10 @@ def get_installed_dependencies(include_extras: bool) -> dict[str, str]:
     installed_packages: dict[str, str] = {}
     for package in importlib.metadata.distributions():
         req_name = package.metadata["name"].lower()
-        if req_name not in direct_deps:
+        req_name_underscores = req_name.replace("-", "_")
+        req_name_dashes = req_name.replace("_", "-")
+        if all(cn not in direct_deps for cn in
+               [req_name, req_name_underscores, req_name_dashes]):
             continue
         installed_packages[req_name] = package.version
     return installed_packages

--- a/medcat/utils/envsnapshot.py
+++ b/medcat/utils/envsnapshot.py
@@ -99,10 +99,11 @@ def get_installed_dependencies(include_extras: bool) -> dict[str, str]:
     installed_packages: dict[str, str] = {}
     for package in importlib.metadata.distributions():
         req_name = package.metadata["name"].lower()
-        req_name_underscores = req_name.replace("-", "_")
+        # NOTE: we're checking against the '-' typed package name not
+        #       the import name (which will have _ instead)
         req_name_dashes = req_name.replace("_", "-")
         if all(cn not in direct_deps for cn in
-               [req_name, req_name_underscores, req_name_dashes]):
+               [req_name, req_name_dashes]):
             continue
         installed_packages[req_name] = package.version
     return installed_packages

--- a/medcat/utils/envsnapshot.py
+++ b/medcat/utils/envsnapshot.py
@@ -108,6 +108,28 @@ def get_installed_dependencies(include_extras: bool) -> dict[str, str]:
     return installed_packages
 
 
+def is_dependency_installed(dependency: str) -> bool:
+    """Checks whether a dependency is installed.
+
+    This takes into account changes such as '-' vs '_'.
+    For example, `typing-extensions` is a direct dependency,
+    but its module path will be `typing_extension` and that's
+    how we can find it as an installed dependency.
+
+    Args:
+        dependency (str): The dependency in question.
+
+    Returns:
+        bool: Whether the depedency has been installed.
+    """
+    installed_deps = get_installed_dependencies(True)
+    dep_name = dependency.lower()
+    dep_name_underscores = dependency.replace("-", "_")
+    dep_name_dashes = dependency.replace("_", "-")
+    options = [dep_name, dep_name_underscores, dep_name_dashes]
+    return any(option in installed_deps for option in options)
+
+
 class Environment(BaseModel, AbstractSerialisable):
     dependencies: dict[str, str]
     transitive_deps: dict[str, str]

--- a/tests/utils/test_envsnapshot.py
+++ b/tests/utils/test_envsnapshot.py
@@ -30,7 +30,7 @@ class DependencyGetterTests(unittest.TestCase):
     def test_all_dir_deps_have_been_installed(self):
         for dep in self.dir_deps:
             with self.subTest(dep):
-                self.assertIn(dep, self.installed_deps)
+                self.assertTrue(envsnapshot.is_dependency_installed(dep))
 
     def test_all_deps_add_to_correct(self):
         # NOTE: didn't account for test/dev deps


### PR DESCRIPTION
The use of the built in `pkg_resources` package is deprecated and produces warnings.

So moving away from it.